### PR TITLE
Disable Content-Type header on 204 No Content

### DIFF
--- a/lib/lotus/action.rb
+++ b/lib/lotus/action.rb
@@ -1,5 +1,6 @@
 require 'lotus/action/configurable'
 require 'lotus/action/rack'
+require 'lotus/action/http'
 require 'lotus/action/mime'
 require 'lotus/action/redirect'
 require 'lotus/action/exposable'
@@ -36,6 +37,7 @@ module Lotus
     #
     # @see Lotus::Action::Rack
     # @see Lotus::Action::Mime
+    # @see Lotus::Action::Http
     # @see Lotus::Action::Redirect
     # @see Lotus::Action::Exposable
     # @see Lotus::Action::Throwable
@@ -47,6 +49,7 @@ module Lotus
       base.class_eval do
         include Rack
         include Mime
+        include Http
         include Redirect
         include Exposable
         include Throwable

--- a/lib/lotus/action/http.rb
+++ b/lib/lotus/action/http.rb
@@ -1,0 +1,17 @@
+module Lotus
+  module Action
+    # Manages HTTP headers and body
+    module Http
+
+      # Ensures that there's no Content-Type if the response code requires
+      # no body
+      def finish
+        super
+        if requires_no_body?
+          headers.delete(Mime::CONTENT_TYPE)
+        end
+      end
+
+    end
+  end
+end

--- a/lib/lotus/action/rack.rb
+++ b/lib/lotus/action/rack.rb
@@ -1,4 +1,5 @@
 require 'securerandom'
+require 'lotus/http/status'
 
 module Lotus
   module Action
@@ -92,6 +93,10 @@ module Lotus
       end
 
       protected
+
+      def requires_no_body?
+        Lotus::Http::Status.requires_no_body?(@_status)
+      end
 
       # Gets the headers from the response
       #

--- a/lib/lotus/action/throwable.rb
+++ b/lib/lotus/action/throwable.rb
@@ -79,7 +79,7 @@ module Lotus
       # @see Lotus::Action::Throwable#handle_exception
       # @see Lotus::Http::Status:ALL
       def halt(code = nil)
-        status(*Http::Status.for_code(code)) if code
+        status(*Lotus::Http::Status.for_code(code)) if code
         throw :halt
       end
 

--- a/lib/lotus/http/status.rb
+++ b/lib/lotus/http/status.rb
@@ -29,6 +29,11 @@ module Lotus
         599 => 'Network connect timeout error'
       }).freeze
 
+      # Status codes that by RFC must not include a message body
+      #
+      # @api private
+      WITHOUT_BODY = Set.new((100..199).to_a << 204 << 205 << 301 << 302 << 304).freeze
+
       # Return a status for the given code
       #
       # @param code [Fixnum] a valid HTTP code
@@ -44,6 +49,17 @@ module Lotus
       #   Lotus::Http::Status.for_code(418) # => [418, "I'm a teapot"]
       def self.for_code(code)
         ALL.assoc(code)
+      end
+
+      # Checks if the given code by RFC must not include a message body
+      #
+      # @param code [Fixnum] a valid HTTP code
+      # @return [Boolean] true if the code requires no body
+      #
+      # @since 0.1.0
+      # @api private
+      def self.requires_no_body?(code)
+        WITHOUT_BODY.include?(code)
       end
     end
   end

--- a/test/integration/mime_type_test.rb
+++ b/test/integration/mime_type_test.rb
@@ -7,7 +7,8 @@ MimeRoutes = Lotus::Router.new do
   get '/configuration', to: 'mimes#configuration'
   get '/accept',        to: 'mimes#accept'
   get '/restricted',    to: 'mimes#restricted'
-  get '/latin',    to: 'mimes#latin'
+  get '/latin',         to: 'mimes#latin'
+  get '/nocontent',     to: 'mimes#no_content'
 end
 
 module Mimes
@@ -71,6 +72,14 @@ module Mimes
     def call(params)
     end
   end
+
+  class NoContent
+    include Lotus::Action
+
+    def call(params)
+      self.status = 204
+    end
+  end
 end
 
 describe 'Content type' do
@@ -101,6 +110,13 @@ describe 'Content type' do
     response.headers['Content-Type'].must_equal 'text/html; charset=latin1'
     response.body.must_equal                    'html'
   end
+
+  it 'does not produce a "Content-Type" header when the request has a 204 No Content status' do
+    response = @app.get('/nocontent')
+    response.headers['Content-Type'].must_be_nil
+    response.body.must_equal                    ''
+  end
+
 
   describe 'when Accept is sent' do
     it 'sets "Content-Type" header according to "Accept"' do

--- a/test/redirect_test.rb
+++ b/test/redirect_test.rb
@@ -7,7 +7,7 @@ describe Lotus::Action do
       response = action.call({})
 
       response[0].must_equal(302)
-      response[1].must_equal({ 'Content-Type' => 'application/octet-stream; charset=utf-8', 'Location' => '/destination' })
+      response[1].must_equal({ 'Location' => '/destination' })
     end
 
     it 'redirects with custom status code' do


### PR DESCRIPTION
As Rack::Lint points out, if the response status is 204, there should not be any Content-Type header set. Let me know if everything is alright with this PR @jodosha. I don't really like having to reference `@_status` outside of Lotus::Action::Rack, but there's no getter :confused: 