### PR TITLE
Eliminate `undefined method `[]' for nil:NilClass` bug

### DIFF
--- a/lib/lotus/action/flash.rb
+++ b/lib/lotus/action/flash.rb
@@ -84,7 +84,7 @@ module Lotus
       # @since x.x.x
       # @api private
       def flash
-        @session[SESSION_KEY]
+        @session[SESSION_KEY] || {}
       end
 
       # The flash registry that holds the data **only for** the current request
@@ -94,7 +94,7 @@ module Lotus
       # @since x.x.x
       # @api private
       def data
-        flash[@request_id]
+        flash[@request_id] || {}
       end
 
       # Expire the stale data from the previous request.


### PR DESCRIPTION
This should handle absence of :__flash key in the session hash.  Obvious this is not a solution for   the bug itself, but just a patch for dealing with consequences.

Closes #65 