### PR TITLE
Fix param coercion with Lotus Validations

### DIFF
--- a/lib/lotus/action/params.rb
+++ b/lib/lotus/action/params.rb
@@ -118,7 +118,11 @@ module Lotus
       #
       # @since 0.2.0
       def [](key)
-        @attributes.get(key)
+        if self.class.whitelisting?
+          public_send(key) if self.class.defined_attributes.include?(key.to_s)
+        else
+          @attributes.get(key)
+        end
       end
 
       # Returns the Ruby's hash
@@ -127,7 +131,11 @@ module Lotus
       #
       # @since 0.3.0
       def to_h
-        @attributes.to_h
+        if self.class.whitelisting?
+          Utils::Hash.new(super).stringify!
+        else
+          @attributes.to_h
+        end
       end
       alias_method :to_hash, :to_h
 
@@ -137,7 +145,11 @@ module Lotus
       # @since 0.3.1
       # @api private
       def read_attributes
-        to_h
+        if self.class.whitelisting?
+          super
+        else
+          to_h
+        end
       end
 
       # @since 0.3.1

--- a/lib/lotus/action/params.rb
+++ b/lib/lotus/action/params.rb
@@ -106,7 +106,7 @@ module Lotus
       # @since 0.1.0
       def initialize(env)
         @env = env
-        _compute_params
+        super(_compute_params)
         # freeze
       end
 

--- a/test/action/params_test.rb
+++ b/test/action/params_test.rb
@@ -128,8 +128,9 @@ describe Lotus::Action::Params do
     before do
       TestParams = Class.new(Lotus::Action::Params) do
         param :email, presence:   true, format: /\A.+@.+\z/
-        param :name,  presence:   true
+        param :name,  type: String, presence:   true
         param :tos,   acceptance: true
+        param :age,   type: Integer
       end
     end
 
@@ -152,6 +153,12 @@ describe Lotus::Action::Params do
 
       params.valid?.must_equal true
       params.errors.must_be_empty
+    end
+
+    it "coerces input" do
+      params = TestParams.new(name: 'John', age: '1')
+      params.name.must_equal('John')
+      params.age.must_equal(1)
     end
   end
 

--- a/test/action/params_test.rb
+++ b/test/action/params_test.rb
@@ -155,10 +155,11 @@ describe Lotus::Action::Params do
       params.errors.must_be_empty
     end
 
-    it "coerces input" do
+    it "has input available as methods" do
       params = TestParams.new(name: 'John', age: '1')
       params.name.must_equal('John')
       params.age.must_equal(1)
+      params[:age].must_equal(1)
     end
   end
 


### PR DESCRIPTION
When using whitelisted parameters, `params[:whatever]` is always nil. Also, type coercion was broken.

I'm not too pleased with the conditionals though, perhaps we could use a separate class for `WhitelistedParams` and `Params`?

Also, there's one failing test I'm unsure of... and I'm heading out now.