### PR TITLE
Nested params

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 
 gem 'lotus-utils',       '~> 0.3', '>= 0.3.1.dev', require: false, github: 'lotus/utils',       branch: '0.3.x'
 gem 'lotus-router',                '>= 0.2.0.dev', require: false, github: 'lotus/router',      branch: '0.2.x'
-gem 'lotus-validations',           '>= 0.2.0.dev', require: false, github: 'lotus/validations', branch: '0.2.x'
+gem 'lotus-validations',           '>= 0.2.0.dev', require: false, github: 'lotus/validations', branch: 'master'
 
 gem 'simplecov', require: false
 gem 'coveralls', require: false

--- a/lib/lotus/action/params.rb
+++ b/lib/lotus/action/params.rb
@@ -80,8 +80,8 @@ module Lotus
       #
       #   params = SignupParams.new({})
       #   params.valid? # => raise ArgumentError
-      def self.param(name, options = {})
-        attribute name, options
+      def self.param(name, options = {}, &block)
+        attribute name, options, &block
         nil
       end
 
@@ -89,6 +89,17 @@ module Lotus
 
       def self.whitelisting?
         defined_attributes.any?
+      end
+
+      # Overrides the method in Lotus::Validation to build a class that
+      # inherits from Params rather than only Lotus::Validations.
+      #
+      # @since x.x.x
+      # @api private
+      def self.build_validation_class(&block)
+        kls = Class.new(Params)
+        kls.class_eval(&block)
+        kls
       end
 
       # @attr_reader env [Hash] the Rack env

--- a/test/action/params_test.rb
+++ b/test/action/params_test.rb
@@ -146,10 +146,14 @@ describe Lotus::Action::Params do
 
       params.valid?.must_equal false
 
-      params.errors.for(:email).must_include Lotus::Validations::Error.new(:email, :presence, true, nil)
-      params.errors.for(:name).must_include  Lotus::Validations::Error.new(:name, :presence, true, nil)
-      params.errors.for(:tos).must_include   Lotus::Validations::Error.new(:tos, :acceptance, true, nil)
-      params.errors.for(:address).for(:line_one).must_include   Lotus::Validations::Error.new(:line_one, :presence, true, nil)
+      params.errors.for(:email).
+        must_include Lotus::Validations::Error.new(:email, :presence, true, nil)
+      params.errors.for(:name).
+        must_include Lotus::Validations::Error.new(:name, :presence, true, nil)
+      params.errors.for(:tos).
+        must_include Lotus::Validations::Error.new(:tos, :acceptance, true, nil)
+      params.errors.for(:address).for(:line_one).
+        must_include Lotus::Validations::Error.new(:line_one, :presence, true, nil)
     end
 
     it "is it valid when all the validation criteria are met" do

--- a/test/action/params_test.rb
+++ b/test/action/params_test.rb
@@ -133,6 +133,9 @@ describe Lotus::Action::Params do
         param :age,   type: Integer
         param :address do
           param :line_one, presence: true
+          param :deep do
+            param :deep_attr, type: String
+          end
         end
       end
     end
@@ -185,6 +188,13 @@ describe Lotus::Action::Params do
     it "has the correct nested param superclass type" do
       params = TestParams.new({address: { line_one: '123'}})
       params[:address].class.superclass.must_equal(Lotus::Action::Params)
+    end
+
+    it "allows nested hash access via symbols" do
+      params = TestParams.new(name: 'John', address: { line_one: '10 High Street', deep: { deep_attr: 1 } })
+      params[:name].must_equal 'John'
+      params[:address][:line_one].must_equal '10 High Street'
+      params[:address][:deep][:deep_attr].must_equal '1'
     end
   end
 

--- a/test/action/params_test.rb
+++ b/test/action/params_test.rb
@@ -131,6 +131,9 @@ describe Lotus::Action::Params do
         param :name,  presence:   true
         param :tos,   acceptance: true
         param :age,   type: Integer
+        param :address do
+          attribute :line_one, presence: true
+        end
       end
     end
 
@@ -146,19 +149,28 @@ describe Lotus::Action::Params do
       params.errors.for(:email).must_include Lotus::Validations::Error.new(:email, :presence, true, nil)
       params.errors.for(:name).must_include  Lotus::Validations::Error.new(:name, :presence, true, nil)
       params.errors.for(:tos).must_include   Lotus::Validations::Error.new(:tos, :acceptance, true, nil)
+      params.errors.for(:address).for(:line_one).must_include   Lotus::Validations::Error.new(:line_one, :presence, true, nil)
     end
 
     it "is it valid when all the validation criteria are met" do
-      params = TestParams.new({email: 'test@lotusrb.org', name: 'Luca', tos: '1'})
+      params = TestParams.new({email: 'test@lotusrb.org', name: 'Luca', tos: '1', address: { line_one: '10 High Street' }})
 
       params.valid?.must_equal true
       params.errors.must_be_empty
     end
 
-    it "has input available as methods" do
-      params = TestParams.new(name: 'John', age: '1')
+    it "has input available through the hash accessor" do
+      params = TestParams.new(name: 'John', age: '1', address: { line_one: '10 High Street' })
       params[:name].must_equal('John')
       params[:age].must_equal(1)
+      params[:address][:line_one].must_equal('10 High Street')
+    end
+
+    it "has input available as methods" do
+      params = TestParams.new(name: 'John', age: '1', address: { line_one: '10 High Street' })
+      params.name.must_equal('John')
+      params.age.must_equal(1)
+      params.address.line_one.must_equal('10 High Street')
     end
   end
 

--- a/test/action/params_test.rb
+++ b/test/action/params_test.rb
@@ -132,7 +132,7 @@ describe Lotus::Action::Params do
         param :tos,   acceptance: true
         param :age,   type: Integer
         param :address do
-          attribute :line_one, presence: true
+          param :line_one, presence: true
         end
       end
     end

--- a/test/action/params_test.rb
+++ b/test/action/params_test.rb
@@ -181,6 +181,11 @@ describe Lotus::Action::Params do
       params = TestParams.new({})
       params.address.wont_be_nil
     end
+
+    it "has the correct nested param superclass type" do
+      params = TestParams.new({address: { line_one: '123'}})
+      params[:address].class.superclass.must_equal(Lotus::Action::Params)
+    end
   end
 
   describe '#to_h' do

--- a/test/action/params_test.rb
+++ b/test/action/params_test.rb
@@ -155,8 +155,8 @@ describe Lotus::Action::Params do
         must_include Lotus::Validations::Error.new(:name, :presence, true, nil)
       params.errors.for(:tos).
         must_include Lotus::Validations::Error.new(:tos, :acceptance, true, nil)
-      params.errors.for(:address).for(:line_one).
-        must_include Lotus::Validations::Error.new(:line_one, :presence, true, nil)
+      params.errors.for('address.line_one').
+        must_include Lotus::Validations::Error.new('address.line_one', :presence, true, nil)
     end
 
     it "is it valid when all the validation criteria are met" do

--- a/test/action/params_test.rb
+++ b/test/action/params_test.rb
@@ -176,6 +176,11 @@ describe Lotus::Action::Params do
       params.age.must_equal(1)
       params.address.line_one.must_equal('10 High Street')
     end
+
+    it "has a nested object even when no input for that object was defined" do
+      params = TestParams.new({})
+      params.address.wont_be_nil
+    end
   end
 
   describe '#to_h' do

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -817,6 +817,33 @@ module FullStack
           redirect_to '/books'
         end
       end
+
+      class Update
+        include FullStack::Action
+
+        params do
+          param :id, type: Integer
+          param :book do
+            param :title, type: String, presence: true
+            param :author do
+              param :name, type: String, presence: true
+              param :favourite_colour
+            end
+          end
+        end
+
+        def call(params)
+          valid = params.valid?
+
+          self.status = 202
+          self.body = Marshal.dump({
+            method_access: params.book.author.name,
+            symbol_access: params[:book][:author][:name],
+            string_access: params['book']['author']['name'],
+            valid: valid
+          })
+        end
+      end
     end
 
     module Poll
@@ -871,7 +898,7 @@ module FullStack
       resolver = Lotus::Routing::EndpointResolver.new(namespace: FullStack::Controllers)
       routes   = Lotus::Router.new(resolver: resolver) do
         get '/', to: 'home#index'
-        resources :books, only: [:index, :create]
+        resources :books, only: [:index, :create, :update]
 
         get '/poll', to: 'poll#start'
 

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -835,12 +835,13 @@ module FullStack
         def call(params)
           valid = params.valid?
 
-          self.status = 202
+          self.status = 201
           self.body = Marshal.dump({
             method_access: params.book.author.name,
             symbol_access: params[:book][:author][:name],
             string_access: params['book']['author']['name'],
-            valid: valid
+            valid: valid,
+            errors: params.errors.to_h
           })
         end
       end

--- a/test/integration/full_stack_test.rb
+++ b/test/integration/full_stack_test.rb
@@ -56,7 +56,22 @@ describe 'Full stack application' do
       method_access: 'Luca',
       symbol_access: 'Luca',
       string_access: 'Luca',
-      valid: true
+      valid: true,
+      errors: {}
+    })
+  end
+
+  it 'validates nested params' do
+    patch '/books/1', {
+      id: '1',
+      book: {
+        title: 'Lotus in Action',
+      }
+    }
+    result = Marshal.load(last_response.body)
+    result[:valid].must_equal false
+    result[:errors].must_equal({
+      'book.author.name' => [Lotus::Validations::Error.new('book.author.name', :presence, true, nil)]
     })
   end
 end

--- a/test/integration/full_stack_test.rb
+++ b/test/integration/full_stack_test.rb
@@ -40,4 +40,23 @@ describe 'Full stack application' do
     # last_response.body.must_include 'FullStack::Controllers::Poll::Step2'
     # last_response.body.must_include %(Step 1 completed)
   end
+
+  it 'can access params with string symbols or methods' do
+    patch '/books/1', {
+      id: '1',
+      book: {
+        title: 'Lotus in Action',
+        author: {
+          name: 'Luca'
+        }
+      }
+    }
+    result = Marshal.load(last_response.body)
+    result.must_equal({
+      method_access: 'Luca',
+      symbol_access: 'Luca',
+      string_access: 'Luca',
+      valid: true
+    })
+  end
 end


### PR DESCRIPTION
Continuing on from the work to [add nested validations in Lotus Validations](https://github.com/lotus/validations/pull/43). This PR aims to finish off the necessary changes to support that here, and also address https://github.com/lotus/controller/issues/70.

The gemspec needed updating to get the validations code with nested attributes, but maybe it's the '0.2.x' branch that needs updating instead though.

(please don't merge yet)