### PR TITLE
#halt now accepts an optional message argument

### DIFF
--- a/lib/lotus/action/throwable.rb
+++ b/lib/lotus/action/throwable.rb
@@ -62,24 +62,29 @@ module Lotus
 
       protected
 
-      # Halt the action execution with the given HTTP status code.
+      # Halt the action execution with the given HTTP status code and message.
       #
       # When used, the execution of a callback or of an action is interrupted
       # and the control returns to the framework, that decides how to handle
       # the event.
       #
-      # It also sets the response body with the message associated to the code
+      # If a message is provided, it sets the response body with the message.
+      # Otherwise, it sets the response body with the default message associated to the code
       # (eg 404 will set `"Not Found"`).
       #
       # @param code [Fixnum] a valid HTTP status code
+      # @param message [String] the response body
       #
       # @since 0.2.0
       #
       # @see Lotus::Controller#handled_exceptions
       # @see Lotus::Action::Throwable#handle_exception
       # @see Lotus::Http::Status:ALL
-      def halt(code = nil)
-        status(*Http::Status.for_code(code)) if code
+      def halt(code = nil, message = nil)
+        if code
+          message ||= Http::Status.for_code(code)[1]
+          status(code, message)
+        end
         throw :halt
       end
 

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -365,7 +365,7 @@ class ThrowCodeAction
   include Lotus::Action
 
   def call(params)
-    halt params[:status]
+    halt params[:status], params[:message]
   end
 end
 

--- a/test/throw_test.rb
+++ b/test/throw_test.rb
@@ -37,6 +37,13 @@ describe Lotus::Action do
       end
     end
 
+    it "throws an HTTP status code with given message" do
+      response = ThrowCodeAction.new.call({ status: 401, message: 'Secret Sauce' })
+
+      response[0].must_equal 401
+      response[2].must_equal ['Secret Sauce']
+    end
+
     it 'throws the code as it is, when not recognized' do
       response = ThrowCodeAction.new.call({ status: 2131231 })
 


### PR DESCRIPTION
When #message is given, it sets the response body with the message.

This is useful in case you need to set a different response for the same HTTP error. For instance, a 403 may be caused by an invalid password, an invalid username, or a bad OAUTH token.