### PR TITLE
Fix rack.errors management

### DIFF
--- a/lib/lotus/action/throwable.rb
+++ b/lib/lotus/action/throwable.rb
@@ -138,6 +138,8 @@ module Lotus
       # @since 0.2.0
       # @api private
       def _reference_in_rack_errors(exception)
+        return if configuration.handled_exception?(exception)
+
         if errors = @_env[RACK_ERRORS]
           errors.write(_dump_exception(exception))
           errors.flush

--- a/lib/lotus/controller/configuration.rb
+++ b/lib/lotus/controller/configuration.rb
@@ -194,6 +194,19 @@ module Lotus
         @handled_exceptions.fetch(exception.class) { DEFAULT_ERROR_CODE }
       end
 
+      # Check if the given exception is handled.
+      #
+      # @param exception [Exception] an exception
+      #
+      # @since x.x.x
+      # @api private
+      #
+      # @see Lotus::Controller::Configuration#handle_exception
+      def handled_exception?(exception)
+        handled_exceptions &&
+          !!@handled_exceptions.fetch(exception.class) { false }
+      end
+
       # Specify which is the default action module to be included when we use
       # the `Lotus::Controller.action` method.
       #

--- a/test/integration/rack_errors_test.rb
+++ b/test/integration/rack_errors_test.rb
@@ -5,13 +5,21 @@ ErrorsRoutes = Lotus::Router.new do
   get '/without_message',     to: 'errors#without_message'
   get '/with_message',        to: 'errors#with_message'
   get '/with_custom_message', to: 'errors#with_custom_message'
+  get '/action_managed',      to: 'errors#action_managed'
+  get '/framework_managed',   to: 'errors#framework_managed'
 end
 
-AuthException       = Class.new(StandardError)
-CustomAuthException = Class.new(StandardError) do
+HandledException          = Class.new(StandardError)
+FrameworkHandledException = Class.new(StandardError)
+AuthException             = Class.new(StandardError)
+CustomAuthException       = Class.new(StandardError) do
   def to_s
     "#{super} :("
   end
+end
+
+Lotus::Controller.configure do
+  handle_exception FrameworkHandledException => 500
 end
 
 module Errors
@@ -38,7 +46,57 @@ module Errors
       raise CustomAuthException, 'plz go away!!'
     end
   end
+
+  class ActionManaged
+    include Lotus::Action
+    handle_exception HandledException => 400
+
+    def call(params)
+      raise HandledException.new
+    end
+  end
+
+  class FrameworkManaged
+    include Lotus::Action
+
+    def call(params)
+      raise FrameworkHandledException.new
+    end
+  end
 end
+
+Lotus::Controller.unload!
+
+DisabledErrorsRoutes = Lotus::Router.new do
+  get '/action_managed',    to: 'disabled_errors#action_managed'
+  get '/framework_managed', to: 'disabled_errors#framework_managed'
+end
+
+Lotus::Controller.configure do
+  handle_exceptions false
+  handle_exception FrameworkHandledException => 500
+end
+
+module DisabledErrors
+  class ActionManaged
+    include Lotus::Action
+    handle_exception HandledException => 400
+
+    def call(params)
+      raise HandledException.new
+    end
+  end
+
+  class FrameworkManaged
+    include Lotus::Action
+
+    def call(params)
+      raise FrameworkHandledException.new
+    end
+  end
+end
+
+Lotus::Controller.unload!
 
 describe 'Reference exception in rack.errors' do
   before do
@@ -58,5 +116,35 @@ describe 'Reference exception in rack.errors' do
   it 'uses exception string representation' do
     response = @app.get('/with_custom_message')
     response.errors.must_include "CustomAuthException: plz go away!! :(\n"
+  end
+
+  it "doesn't dump exception in rack.errors if it's managed by an action" do
+    response = @app.get('/action_managed')
+    response.errors.must_be_empty
+  end
+
+  it "doesn't dump exception in rack.errors if it's managed by the framework" do
+    response = @app.get('/framework_managed')
+    response.errors.must_be_empty
+  end
+
+  describe 'when exception management is disabled' do
+    before do
+      @app = Rack::MockRequest.new(DisabledErrorsRoutes)
+    end
+
+    it "dumps the exception in rack.errors even if it's managed by the action" do
+      -> {
+        response = @app.get('/action_managed')
+        response.errors.wont_be_empty
+      }.must_raise(HandledException)
+    end
+
+    it "dumps the exception in rack.errors even if it's managed by the framework" do
+      -> {
+        response = @app.get('/framework_managed')
+        response.errors.wont_be_empty
+      }.must_raise(FrameworkHandledException)
+    end
   end
 end


### PR DESCRIPTION
Only dump exceptions in rack.errors if handling is turned off, or the raised exception isn't managed

Closes #74 

/cc @joneslee85 and @weppos 