### PR TITLE
Simplify .travis.yml as jruby-head is in 2.2 mode by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,8 @@ rvm:
   - 2.1.5
   - 2.2
   - rbx-2
+  - jruby-head
 
 matrix:
-  include:
-    - rvm: jruby
-      env: JRUBY_OPTS="--2.0"
-    - rvm: jruby-head
-      env: JRUBY_OPTS="--2.1"
   allow_failures:
-    - rvm: jruby
     - rvm: jruby-head


### PR DESCRIPTION
* old JRuby is old, no need to test

FYI I also filed a bug for the one failing spec on JRuby here - yay open source :)

Cheers,
Tobi