### PR TITLE
Introduced Lotus::Action::Params#get

### DIFF
--- a/lib/lotus/action/params.rb
+++ b/lib/lotus/action/params.rb
@@ -26,6 +26,14 @@ module Lotus
       # @since 0.1.0
       ROUTER_PARAMS = 'router.params'.freeze
 
+      # Separator for #get
+      #
+      # @since x.x.x
+      # @api private
+      #
+      # @see Lotus::Action::Params#get
+      GET_SEPARATOR = '.'.freeze
+
       # Whitelist and validate a parameter
       #
       # @param name [#to_sym] The name of the param to whitelist
@@ -135,6 +143,52 @@ module Lotus
       # @since 0.2.0
       def [](key)
         @attributes.get(key)
+      end
+
+      # Get an attribute value associated with the given key.
+      # Nested attributes are reached with a dot notation.
+      #
+      # @param key [String] the key
+      #
+      # @return [Object,NilClass] return the associated value, if found
+      #
+      # @since x.x.x
+      #
+      # @example
+      #   require 'lotus/controller'
+      #
+      #   module Deliveries
+      #     class Create
+      #       include Lotus::Action
+      #
+      #       params do
+      #         param :customer_name
+      #         param :address do
+      #           param :city
+      #         end
+      #       end
+      #
+      #       def call(params)
+      #         params.get('customer_name')   # => "Luca"
+      #         params.get('uknown')          # => nil
+      #
+      #         params.get('address.city')    # => "Rome"
+      #         params.get('address.unknown') # => nil
+      #
+      #         params.get(nil)               # => nil
+      #       end
+      #     end
+      #   end
+      def get(key)
+        key, *keys = key.to_s.split(GET_SEPARATOR)
+        result     = self[key]
+
+        Array(keys).each do |k|
+          break if result.nil?
+          result = result[k]
+        end
+
+        result
       end
 
       # Returns the Ruby's hash

--- a/test/action/params_test.rb
+++ b/test/action/params_test.rb
@@ -155,25 +155,6 @@ describe Lotus::Action::Params do
   end
 
   describe 'validations' do
-    before do
-      TestParams = Class.new(Lotus::Action::Params) do
-        param :email, presence:   true, format: /\A.+@.+\z/
-        param :name,  presence:   true
-        param :tos,   acceptance: true
-        param :age,   type: Integer
-        param :address do
-          param :line_one, presence: true
-          param :deep do
-            param :deep_attr, type: String
-          end
-        end
-      end
-    end
-
-    after do
-      Object.send(:remove_const, :TestParams)
-    end
-
     it "isn't valid with empty params" do
       params = TestParams.new({})
 
@@ -225,6 +206,32 @@ describe Lotus::Action::Params do
       params[:name].must_equal 'John'
       params[:address][:line_one].must_equal '10 High Street'
       params[:address][:deep][:deep_attr].must_equal '1'
+    end
+  end
+
+  describe '#get' do
+    before do
+      @params = TestParams.new(name: 'John', address: { line_one: '10 High Street', deep: { deep_attr: 1 } })
+    end
+
+    it 'returns nil for nil argument' do
+      @params.get(nil).must_be_nil
+    end
+
+    it 'returns nil for unknown param' do
+      @params.get('unknown').must_be_nil
+    end
+
+    it 'allows to read top level param' do
+      @params.get('name').must_equal 'John'
+    end
+
+    it 'allows to read nested param' do
+      @params.get('address.line_one').must_equal '10 High Street'
+    end
+
+    it 'returns nil for uknown nested param' do
+      @params.get('address.unknown').must_be_nil
     end
   end
 

--- a/test/action/params_test.rb
+++ b/test/action/params_test.rb
@@ -210,28 +210,56 @@ describe Lotus::Action::Params do
   end
 
   describe '#get' do
-    before do
-      @params = TestParams.new(name: 'John', address: { line_one: '10 High Street', deep: { deep_attr: 1 } })
+    describe 'with data' do
+      before do
+        @params = TestParams.new(name: 'John', address: { line_one: '10 High Street', deep: { deep_attr: 1 } })
+      end
+
+      it 'returns nil for nil argument' do
+        @params.get(nil).must_be_nil
+      end
+
+      it 'returns nil for unknown param' do
+        @params.get('unknown').must_be_nil
+      end
+
+      it 'allows to read top level param' do
+        @params.get('name').must_equal 'John'
+      end
+
+      it 'allows to read nested param' do
+        @params.get('address.line_one').must_equal '10 High Street'
+      end
+
+      it 'returns nil for uknown nested param' do
+        @params.get('address.unknown').must_be_nil
+      end
     end
 
-    it 'returns nil for nil argument' do
-      @params.get(nil).must_be_nil
-    end
+    describe 'without data' do
+      before do
+        @params = TestParams.new({})
+      end
 
-    it 'returns nil for unknown param' do
-      @params.get('unknown').must_be_nil
-    end
+      it 'returns nil for nil argument' do
+        @params.get(nil).must_be_nil
+      end
 
-    it 'allows to read top level param' do
-      @params.get('name').must_equal 'John'
-    end
+      it 'returns nil for unknown param' do
+        @params.get('unknown').must_be_nil
+      end
 
-    it 'allows to read nested param' do
-      @params.get('address.line_one').must_equal '10 High Street'
-    end
+      it 'returns nil for top level param' do
+        @params.get('name').must_be_nil
+      end
 
-    it 'returns nil for uknown nested param' do
-      @params.get('address.unknown').must_be_nil
+      it 'returns nil for nested param' do
+        @params.get('address.line_one').must_be_nil
+      end
+
+      it 'returns nil for uknown nested param' do
+        @params.get('address.unknown').must_be_nil
+      end
     end
   end
 

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -603,6 +603,19 @@ class ParamsValidationAction
   end
 end
 
+class TestParams < Lotus::Action::Params
+  param :email, presence:   true, format: /\A.+@.+\z/
+  param :name,  presence:   true
+  param :tos,   acceptance: true
+  param :age,   type: Integer
+  param :address do
+    param :line_one, presence: true
+    param :deep do
+      param :deep_attr, type: String
+    end
+  end
+end
+
 class Root
   include Lotus::Action
 


### PR DESCRIPTION
## What

Introduced `Lotus::Action::Params#get` as a safe way to access (nested) attributes.

## Why?

  1. Developers can **safely access nested params** without worrying of `NoMethodErrors` that can be caused by the subscriber notation. Eg `params[:address][:street]`, if `:address` isn't sent, the action will blow up. The lack of this new suggested API (`#get`) will force developers to write defensive code to access nested attributes.
  2. This serves as supporting feature for Lotus::Helpers' form helper. In case of param validation failures, a form should be able to be rendered again and **keep the current values**.

## Usage

```ruby
require 'lotus/controller'

module Deliveries
  class Create
    include Lotus::Action

    params do
      param :customer_name
      param :address do
        param :city
      end
    end

    def call(params)
      params.get('customer_name')   # => "Luca"
      params.get('uknown')          # => nil

      params.get('address.city')    # => "Rome"
      params.get('address.unknown') # => nil

      params.get(nil)               # => nil
    end
  end
end
```
