### PR TITLE
Fix redirect_to inside callback and doesn't call `call` method in action

### DIFF
--- a/lib/lotus/action/redirect.rb
+++ b/lib/lotus/action/redirect.rb
@@ -12,12 +12,14 @@ module Lotus
 
       private
 
-      # Redirect to the given URL
+      # Redirect to the given URL and halt the request
       #
       # @param url [String] the destination URL
       # @param status [Fixnum] the http code
       #
       # @since 0.1.0
+      #
+      # @see Lotus::Action::Throwable#halt
       #
       # @example With default status code (302)
       #   require 'lotus/controller'
@@ -50,7 +52,7 @@ module Lotus
       #   action.call({}) # => [301, {'Location' => '/articles/23'}, '']
       def redirect_to(url, status: 302)
         headers[LOCATION] = url
-        self.status = status
+        halt(status)
       end
     end
   end

--- a/lib/lotus/action/session.rb
+++ b/lib/lotus/action/session.rb
@@ -112,8 +112,8 @@ module Lotus
       #   # The validation errors caused by Comments::Create are available
       #   # **after the redirect** in the context of Comments::Index.
       def redirect_to(*args)
-        super
         flash[ERRORS_KEY] = errors.to_a unless params.valid?
+        super
       end
 
       # Read errors from flash or delegate to the superclass

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -1050,6 +1050,29 @@ module FullStack
         end
       end
     end
+
+    module Users
+      class Show
+        include FullStack::Action
+
+        before :redirect_to_root
+        after :set_body
+
+        def call(params)
+          self.body = "call method shouldn't be called"
+        end
+
+        private
+
+        def redirect_to_root
+          redirect_to '/'
+        end
+
+        def set_body
+          self.body = "after callbacl shouldn't be called"
+        end
+      end
+    end
   end
 
   class Renderer
@@ -1079,6 +1102,10 @@ module FullStack
           post '/1', to: 'poll#step1'
           get  '/2', to: 'poll#step2'
           post '/2', to: 'poll#step2'
+        end
+
+        namespace 'users' do
+          get '/1', to: 'users#show'
         end
       end
 

--- a/test/integration/full_stack_test.rb
+++ b/test/integration/full_stack_test.rb
@@ -81,4 +81,11 @@ describe 'Full stack application' do
       'book.author.name' => [Lotus::Validations::Error.new('book.author.name', :presence, true, nil)]
     })
   end
+
+  it "redirect in before action and call action method doesn't called" do
+    get 'users/1'
+
+    last_response.status.must_equal 302
+    last_response.body.must_equal 'Found' # This message is 302 status
+  end
 end


### PR DESCRIPTION
fix #93 

This PR fixes a problem if a person does a `redirect_to` inside a before callback the `call` method in an action is called.