### PR TITLE
Allow blocks when specifying Rack middleware to use

### DIFF
--- a/lib/lotus/action/rack.rb
+++ b/lib/lotus/action/rack.rb
@@ -94,8 +94,8 @@ module Lotus
         #       end
         #     end
         #   end
-        def use(middleware, *args)
-          rack_builder.use middleware, *args
+        def use(middleware, *args, &block)
+          rack_builder.use middleware, *args, &block
         end
       end
 

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -170,6 +170,18 @@ class ExposeAction
   end
 end
 
+class ZMiddleware
+  def initialize(app, &message)
+    @app = app
+    @message = message
+  end
+
+  def call(env)
+    code, headers, body = @app.call(env)
+    [code, headers.merge!('Z-Middleware' => @message.call), body]
+  end
+end
+
 class YMiddleware
   def initialize(app)
     @app = app
@@ -208,6 +220,17 @@ module UseAction
 
     def call(params)
       self.body = 'Hello from UseAction::Show'
+    end
+  end
+
+  class Edit
+    include Lotus::Action
+    use ZMiddleware do
+      'OK'
+    end
+
+    def call(params)
+      self.body = 'Hello from UseAction::Edit'
     end
   end
 end

--- a/test/integration/use_test.rb
+++ b/test/integration/use_test.rb
@@ -15,6 +15,7 @@ describe 'Rack middleware integration' do
       router = Lotus::Router.new do
         get '/', to: 'use_action#index'
         get '/show', to: 'use_action#show'
+        get '/edit', to: 'use_action#edit'
       end
 
       UseActionApplication = Rack::Builder.new do
@@ -34,6 +35,14 @@ describe 'Rack middleware integration' do
       response.headers.fetch('Y-Middleware').must_equal 'OK'
       response.headers['X-Middleware'].must_be_nil
       response.body.must_equal 'Hello from UseAction::Show'
+
+      get '/edit'
+
+      response.status.must_equal 200
+      response.headers.fetch('Z-Middleware').must_equal 'OK'
+      response.headers['X-Middleware'].must_be_nil
+      response.headers['Y-Middleware'].must_be_nil
+      response.body.must_equal 'Hello from UseAction::Edit'
     end
   end
 


### PR DESCRIPTION
I am using Lotus::Controller outside of a Lotus application and ran into a problem when trying to use Rack::Auth::Basic. I was trying to configure it just like below:

```
Lotus::Controller.configure do
  prepare do
    use Rack::Auth::Basic, "Protected Area" do |username, password|
      username == 'admin' && password == 'password'
    end
  end
end
```

But I noticed that `Lotus::Action::Rack::ClassMethods#use` does not accept blocks when specifying middleware. I checked https://github.com/rack/rack/blob/master/lib/rack/builder.rb#L81 and `Rack::Builder#use` does accept blocks.

Is this intended behavior? Am I missing something?