### PR TITLE
Rack::Lint compatibility

### DIFF
--- a/lib/lotus/action/head.rb
+++ b/lib/lotus/action/head.rb
@@ -30,11 +30,9 @@ module Lotus
         'Allow'            => true,
         'Content-Encoding' => true,
         'Content-Language' => true,
-        'Content-Length'   => true,
         'Content-Location' => true,
         'Content-MD5'      => true,
         'Content-Range'    => true,
-        'Content-Type'     => true,
         'Expires'          => true,
         'Last-Modified'    => true,
         'extension-header' => true

--- a/test/integration/head_test.rb
+++ b/test/integration/head_test.rb
@@ -62,21 +62,18 @@ describe 'HEAD' do
         response.headers['Content-Language'].must_equal 'en'
       end
 
-      # FIXME Review this
-      unless [204, 205, 304].include?(code)
-        it "sends Content-Length header" do
-          get "/code/#{ code }"
+      it "doesn't send Content-Length header" do
+        get "/code/#{ code }"
 
-          response.status.must_equal(code)
-          response.headers['Content-Length'].must_equal 4
-        end
+        response.status.must_equal(code)
+        response.headers.key?('Content-Length').must_equal false
+      end
 
-        it "sends Content-Type header" do
-          get "/code/#{ code }"
+      it "doesn't send Content-Type header" do
+        get "/code/#{ code }"
 
-          response.status.must_equal(code)
-          response.headers['Content-Type'].must_equal 'application/octet-stream; charset=utf-8'
-        end
+        response.status.must_equal(code)
+        response.headers.key?('Content-Type').must_equal false
       end
 
       it "sends Content-Location header" do


### PR DESCRIPTION
## Problem

Both `Rack::Lint` and Rack SPEC aren't compliant with RFC 2016 (see https://github.com/rack/rack/issues/787) for entity headers.

The RFC allows headers like `Content-Type` and `Content-Length` to be sent when the status code is `204`, but `Rack::Lint` don't.

## Solution

We make Lotus compliant with `Rack::Lint` until they don't fix this problem.