### PR TITLE
Added automatically expires option if max_age option presents

### DIFF
--- a/lib/lotus/action/cookie_jar.rb
+++ b/lib/lotus/action/cookie_jar.rb
@@ -98,11 +98,21 @@ module Lotus
       # @api private
       def _merge_default_values(value)
         cookies_options = if value.is_a? Hash
-          value
+          value.merge(_add_expires_option(value) || {})
         else
           { value: value }
         end
         @default_options.merge cookies_options
+      end
+
+      # Add expires option to cookies if :max_age presents
+      #
+      # @since x.x.x
+      # @api private
+      def _add_expires_option(value)
+        if value.has_key?(:max_age) && !value.has_key?(:expires)
+          { expires: (Time.now + value[:max_age]) }
+        end
       end
 
       # Extract the cookies from the raw Rack env.

--- a/test/cookies_test.rb
+++ b/test/cookies_test.rb
@@ -62,5 +62,17 @@ describe Lotus::Action do
         headers.must_equal({'Content-Type' => 'application/octet-stream; charset=utf-8', 'Set-Cookie' => 'bar=foo; domain=lotusrb.com; path=/action'})
       end
     end
+
+    describe 'with max_age option and without expires option' do
+      it 'automatically set expires option' do
+        Time.stub :now, Time.now do
+          action = GetAutomaticallyExpiresCookiesAction.new
+          _, headers, _ = action.call({})
+          max_age = 120
+          headers["Set-Cookie"].must_include("max-age=#{max_age}")
+          headers["Set-Cookie"].must_include("expires=#{(Time.now + max_age).gmtime.rfc2822}")
+        end
+      end
+    end
   end
 end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -463,6 +463,15 @@ class GetOverwrittenCookiesAction
   end
 end
 
+class GetAutomaticallyExpiresCookiesAction
+  include Lotus::Action
+  include Lotus::Action::Cookies
+
+  def call(params)
+    cookies[:bar] = { value: 'foo', max_age: 120 }
+  end
+end
+
 class SetCookiesAction
   include Lotus::Action
   include Lotus::Action::Cookies


### PR DESCRIPTION
Closes #107 

Now when you set max_age in a cookie, automatically expires option is set (Time.now + max_age option).
```ruby
cookies[:foo] = { value: 'bar', max_age: 120 }
```
```ruby
"'Set-Cookie' => 'bar=foo; max-age=120; expires=Fri, 15 May 2015 10:49:42 -0000'"
```