### PR TITLE
Fixes bug #113 where Params are incorrectly converted to hashes.

### DIFF
--- a/lib/lotus/action/params.rb
+++ b/lib/lotus/action/params.rb
@@ -119,7 +119,11 @@ module Lotus
       # @since 0.3.2
       # @api private
       def self.build_validation_class(&block)
-        kls = Class.new(Params)
+        kls = Class.new(Params) do
+          def lotus_nested_attributes?
+            true
+          end
+        end
         kls.class_eval(&block)
         kls
       end

--- a/test/action/params_test.rb
+++ b/test/action/params_test.rb
@@ -314,6 +314,29 @@ describe Lotus::Action::Params do
         h.must_be_kind_of(::Hash)
       end
     end
+  
+    describe 'when whitelisting' do
+      # This is bug 113.
+      it 'handles nested params' do
+        hash = {
+          'name' => 'John',
+          'age' => 1,
+          'address' => {
+            'line_one' => '10 High Street',
+            'deep' => {
+              'deep_attr' => 'hello',
+            }
+          }
+        }
+
+        actual = TestParams.new(hash).to_h
+        actual.must_equal(hash)
+
+        actual.must_be_kind_of(::Hash)
+        actual['address'].must_be_kind_of(::Hash)
+        actual['address']['deep'].must_be_kind_of(::Hash)
+      end
+    end
   end
 
   describe '#to_hash' do


### PR DESCRIPTION
The problem occurs when we're using whitelisting and nested
parameters.  When attribute definitions are created in the context
of Lotus::Action::Params the anonymous Params subclass which is
created does not respond to the :lotus_nested_attributes? method
which is expected by Lotus::Utils::Attribues#to_h.

The fix is to make the anonymous class respond to that method with
the right value.  This is a little hacky for two reasons:

1. You need to look at the source for
Lotus::Validations::AttributeDefiner to understand this.
2. It might make sense to create a NestParams class in
Lotus::Action.