### PR TITLE
Guarantees specific error_handler catch was called against a more

### DIFF
--- a/lib/lotus/controller/configuration.rb
+++ b/lib/lotus/controller/configuration.rb
@@ -194,7 +194,10 @@ module Lotus
         handler = nil
 
         @handled_exceptions.each do |exception_class, h|
-          handler = h if exception.kind_of?(exception_class)
+          if exception.kind_of?(exception_class)
+            handler = h
+            break
+          end
         end
 
         handler || DEFAULT_ERROR_CODE

--- a/test/action_test.rb
+++ b/test/action_test.rb
@@ -53,6 +53,13 @@ describe Lotus::Action do
         response[2].must_equal ['An inherited exception occurred!']
       end
 
+      it 'handles exception with specified method' do
+        response = ErrorCallFromInheritedErrorClassStack.new.call({})
+
+        response[0].must_equal 501
+        response[2].must_equal ['MyCustomError was thrown']
+      end
+
       it 'handles exception with specified method (symbol)' do
         response = ErrorCallWithSymbolMethodNameAsHandlerAction.new.call({})
 

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -119,7 +119,27 @@ class ErrorCallFromInheritedErrorClass
 
   private
   def handler(exception)
-    status 501, 'Please go away!'
+    status 501, 'An inherited exception occurred!'
+  end
+end
+
+class ErrorCallFromInheritedErrorClassStack
+  include Lotus::Action
+
+  handle_exception MyCustomError => :handler
+  handle_exception StandardError => :standard_handler
+
+  def call(params)
+    raise MyCustomError
+  end
+
+  private
+  def handler(exception)
+    status 501, 'MyCustomError was thrown'
+  end
+
+  def standard_handler(exception)
+    status 501, 'An unknown error was thrown'
   end
 end
 


### PR DESCRIPTION
Hi guys, 

I made a mistake on my last PR. When you have a stack of error_handlers from more specific errors to more generic error catcher, the last one always be called. 

This PR fixes it. 

Sorry by my mistake.