### PR TITLE
introduces request and response format and deprecates default_format

### DIFF
--- a/lib/lotus/action/mime.rb
+++ b/lib/lotus/action/mime.rb
@@ -1,6 +1,7 @@
 require 'rack/utils'
 require 'lotus/utils'
 require 'lotus/utils/kernel'
+require 'lotus/utils/deprecation'
 
 module Lotus
   module Action
@@ -169,7 +170,7 @@ module Lotus
       # @since 0.1.0
       #
       # @see Lotus::Action::Mime#format=
-      # @see Lotus::Configuration#default_format
+      # @see Lotus::Configuration#default_request_format
       # @see Lotus::Action::Mime#default_content_type
       # @see Lotus::Action::Mime#DEFAULT_CONTENT_TYPE
       #
@@ -185,7 +186,7 @@ module Lotus
       #     end
       #   end
       def content_type
-        @content_type || accepts || default_content_type || DEFAULT_CONTENT_TYPE
+        @content_type || default_response_type || accepts || default_content_type || DEFAULT_CONTENT_TYPE
       end
 
       # Action charset setter, receives new charset value
@@ -421,12 +422,18 @@ module Lotus
         end
       end
 
+      # @since 0.5.0 - TODO: Confirm?
+      # @api private
+      def default_response_type
+        self.class.format_to_mime_type(configuration.default_response_format) if configuration.default_response_format
+      end
+
       # @since 0.2.0
       # @api private
       def default_content_type
         self.class.format_to_mime_type(
-          configuration.default_format
-        ) if configuration.default_format
+          configuration.default_request_format
+        ) if configuration.default_request_format
       end
 
       # @since 0.2.0

--- a/lib/lotus/controller/configuration.rb
+++ b/lib/lotus/controller/configuration.rb
@@ -418,35 +418,92 @@ module Lotus
       # an argument, it will set the corresponding instance variable. When
       # called without, it will return the already set value, or the default.
       #
-      # @overload default_format(format)
+      # @overload default_request_format(format)
       #   Sets the given value
       #   @param format [#to_sym] the symbol format
       #   @raise [TypeError] if it cannot be coerced to a symbol
       #
-      # @overload default_format
+      # @overload default_request_format
       #   Gets the value
       #   @return [Symbol,nil]
       #
-      # @since 0.2.0
       #
       # @see Lotus::Action::Mime
       #
       # @example Getting the value
       #   require 'lotus/controller'
       #
-      #   Lotus::Controller.configuration.default_format # => nil
+      #   Lotus::Controller.configuration.default_request_format # => nil
       #
       # @example Setting the value
       #   require 'lotus/controller'
       #
       #   Lotus::Controller.configure do
-      #     default_format :html
+      #     default_request_format :html
       #   end
-      def default_format(format = nil)
+      #
+      # @since 0.5.0 TODO: Confirm?
+      def default_request_format(format = nil)
         if format
-          @default_format = Utils::Kernel.Symbol(format)
+          @default_request_format = Utils::Kernel.Symbol(format)
         else
-          @default_format
+          @default_request_format
+        end
+      end
+
+      # Set a format as default fallback for all the requests without a strict
+      # requirement for the mime type.
+      #
+      # @since 0.2.0
+      #
+      # @deprecated Use {#default_request_format} instead.
+      def default_format(format = nil)
+        Lotus::Utils::Deprecation.new('default_format is deprecated, please use default_request_format')
+        default_request_format(format)
+      end
+
+      # Set a format to be used for all responses regardless of the request type.
+      #
+      # The given format must be coercible to a symbol, and be a valid mime type
+      # alias. If it isn't, at the runtime the framework will raise a
+      # `Lotus::Controller::UnknownFormatError`.
+      #
+      # By default this value is nil.
+      #
+      # This is part of a DSL, for this reason when this method is called with
+      # an argument, it will set the corresponding instance variable. When
+      # called without, it will return the already set value, or the default.
+      #
+      # @overload default_response_format(format)
+      #   Sets the given value
+      #   @param format [#to_sym] the symbol format
+      #   @raise [TypeError] if it cannot be coerced to a symbol
+      #
+      # @overload default_response_format
+      #   Gets the value
+      #   @return [Symbol,nil]
+      #
+      #
+      # @see Lotus::Action::Mime
+      #
+      # @example Getting the value
+      #   require 'lotus/controller'
+      #
+      #   Lotus::Controller.configuration.default_response_format # => nil
+      #
+      # @example Setting the value
+      #   require 'lotus/controller'
+      #
+      #   Lotus::Controller.configure do
+      #     default_response_format :json
+      #   end
+      #
+      # @since 0.5.0 TODO: Confirm?
+      def default_response_format(format = nil)
+        if format
+          @default_response_format = Utils::Kernel.Symbol(format)
+        else
+          @default_response_format
         end
       end
 
@@ -578,7 +635,8 @@ module Lotus
           c.action_module           = action_module
           c.modules                 = modules.dup
           c.formats                 = formats.dup
-          c.default_format          = default_format
+          c.default_request_format  = default_request_format
+          c.default_response_format = default_response_format
           c.default_charset         = default_charset
           c.default_headers         = default_headers.dup
           c.cookies = cookies.dup
@@ -600,15 +658,16 @@ module Lotus
       # @since 0.2.0
       # @api private
       def reset!
-        @handle_exceptions  = true
-        @handled_exceptions = {}
-        @modules            = []
-        @formats            = DEFAULT_FORMATS.dup
-        @default_format     = nil
-        @default_charset    = nil
-        @default_headers    = {}
-        @cookies            = {}
-        @action_module      = ::Lotus::Action
+        @handle_exceptions       = true
+        @handled_exceptions      = {}
+        @modules                 = []
+        @formats                 = DEFAULT_FORMATS.dup
+        @default_request_format  = nil
+        @default_response_format = nil
+        @default_charset         = nil
+        @default_headers         = {}
+        @cookies                 = {}
+        @action_module           = ::Lotus::Action
       end
 
       # Copy the configuration for the given action
@@ -641,7 +700,8 @@ module Lotus
       attr_accessor :formats
       attr_writer :action_module
       attr_writer :modules
-      attr_writer :default_format
+      attr_writer :default_request_format
+      attr_writer :default_response_format
       attr_writer :default_charset
       attr_writer :default_headers
       attr_writer :cookies

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -188,6 +188,16 @@ describe Lotus::Controller::Configuration do
   end
 
   describe '#default_format' do
+
+    describe "deprecation" do
+      it "outputs deprecation warning" do
+        _, err = capture_io do
+          @configuration.default_format :html
+        end
+        err.must_include "default_format is deprecated, please use default_request_format"
+      end
+    end
+
     describe "when not previously set" do
       it 'returns nil' do
         @configuration.default_format.must_be_nil
@@ -206,6 +216,50 @@ describe Lotus::Controller::Configuration do
 
     it 'raises an error if the given format cannot be coerced into symbol' do
       -> { @configuration.default_format(23) }.must_raise TypeError
+    end
+  end
+
+  describe '#default_request_format' do
+    describe "when not previously set" do
+      it 'returns nil' do
+        @configuration.default_request_format.must_be_nil
+      end
+    end
+
+    describe "when set" do
+      before do
+        @configuration.default_request_format :html
+      end
+
+      it 'returns the value' do
+        @configuration.default_request_format.must_equal :html
+      end
+    end
+
+    it 'raises an error if the given format cannot be coerced into symbol' do
+      -> { @configuration.default_request_format(23) }.must_raise TypeError
+    end
+  end
+
+  describe '#default_response_format' do
+    describe "when not previously set" do
+      it 'returns nil' do
+        @configuration.default_response_format.must_be_nil
+      end
+    end
+
+    describe "when set" do
+      before do
+        @configuration.default_response_format :json
+      end
+
+      it 'returns the value' do
+        @configuration.default_response_format.must_equal :json
+      end
+    end
+
+    it 'raises an error if the given format cannot be coerced into symbol' do
+      -> { @configuration.default_response_format(23) }.must_raise TypeError
     end
   end
 
@@ -324,21 +378,23 @@ describe Lotus::Controller::Configuration do
       @configuration.reset!
       @configuration.prepare { include Kernel }
       @configuration.format custom: 'custom/format'
-      @configuration.default_format :html
+      @configuration.default_request_format :html
+      @configuration.default_response_format :html
       @configuration.default_charset 'latin1'
       @configuration.default_headers({ 'X-Frame-Options' => 'DENY' })
       @config = @configuration.duplicate
     end
 
     it 'returns a copy of the configuration' do
-      @config.handle_exceptions.must_equal  @configuration.handle_exceptions
-      @config.handled_exceptions.must_equal @configuration.handled_exceptions
-      @config.action_module.must_equal      @configuration.action_module
-      @config.modules.must_equal            @configuration.modules
-      @config.send(:formats).must_equal     @configuration.send(:formats)
-      @config.default_format.must_equal     @configuration.default_format
-      @config.default_charset.must_equal    @configuration.default_charset
-      @config.default_headers.must_equal    @configuration.default_headers
+      @config.handle_exceptions.must_equal       @configuration.handle_exceptions
+      @config.handled_exceptions.must_equal      @configuration.handled_exceptions
+      @config.action_module.must_equal           @configuration.action_module
+      @config.modules.must_equal                 @configuration.modules
+      @config.send(:formats).must_equal          @configuration.send(:formats)
+      @config.default_request_format.must_equal  @configuration.default_request_format
+      @config.default_response_format.must_equal @configuration.default_response_format
+      @config.default_charset.must_equal         @configuration.default_charset
+      @config.default_headers.must_equal         @configuration.default_headers
     end
 
     it "doesn't affect the original configuration" do
@@ -347,7 +403,8 @@ describe Lotus::Controller::Configuration do
       @config.action_module    CustomAction
       @config.prepare          { include Comparable }
       @config.format another: 'another/format'
-      @config.default_format :json
+      @config.default_request_format  :json
+      @config.default_response_format :json
       @config.default_charset 'utf-8'
       @config.default_headers({ 'X-Frame-Options' => 'ALLOW ALL' })
 
@@ -356,7 +413,8 @@ describe Lotus::Controller::Configuration do
       @config.action_module.must_equal               CustomAction
       @config.modules.size.must_equal                2
       @config.format_for('another/format').must_equal :another
-      @config.default_format.must_equal               :json
+      @config.default_request_format.must_equal       :json
+      @config.default_response_format.must_equal      :json
       @config.default_charset.must_equal              'utf-8'
       @config.default_headers.must_equal              ({ 'X-Frame-Options' => 'ALLOW ALL' })
 
@@ -365,7 +423,8 @@ describe Lotus::Controller::Configuration do
       @configuration.action_module.must_equal      ::Lotus::Action
       @configuration.modules.size.must_equal       1
       @configuration.format_for('another/format').must_be_nil
-      @configuration.default_format.must_equal     :html
+      @configuration.default_request_format.must_equal  :html
+      @configuration.default_response_format.must_equal :html
       @configuration.default_charset.must_equal    'latin1'
       @configuration.default_headers.must_equal    ({ 'X-Frame-Options' => 'DENY' })
     end
@@ -378,7 +437,8 @@ describe Lotus::Controller::Configuration do
       @configuration.action_module    CustomAction
       @configuration.modules          { include Kernel }
       @configuration.format another: 'another/format'
-      @configuration.default_format :another
+      @configuration.default_request_format  :another
+      @configuration.default_response_format :another
       @configuration.default_charset 'kor-1'
       @configuration.default_headers({ 'X-Frame-Options' => 'ALLOW DENY' })
 
@@ -391,7 +451,8 @@ describe Lotus::Controller::Configuration do
       @configuration.action_module.must_equal(::Lotus::Action)
       @configuration.modules.must_equal([])
       @configuration.send(:formats).must_equal(Lotus::Controller::Configuration::DEFAULT_FORMATS)
-      @configuration.default_format.must_be_nil
+      @configuration.default_request_format.must_be_nil
+      @configuration.default_response_format.must_be_nil
       @configuration.default_charset.must_be_nil
       @configuration.default_headers.must_equal({})
     end


### PR DESCRIPTION
Recap..

As per my issue #111  and suggestion from Luca, this PR introduces `default_request_format` and `response_request_format` and deprecates `default_format`. 

The premise behind it is:

`default_request_format` behaves the same as `default_format`. However, now it's clear what default format we're setting. request..

`default_response_format` will set it's value to all responses. It can only be overwritten by directly setting `self.format = :whatever` in the action itself. If a value is not set, it will then behave as it did before (try to guess response format based on request format etc...)

`default_format` has been deprecated and should be removed eventually.

Please have a look and let me know what you think. :-)

Notes:

* There's a PR on lotus/lotus that addresses the same thing.
* I've versioned the new methods to 0.5.0 as I assume that's when it will be introduced, but that needs to be confirmed. thoughts?

Closes #111
