### PR TITLE
Fix specs when running on JRuby.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: ruby
 sudo: false
 cache: bundler
 script: 'bundle exec rake test:coverage --trace'
+before_install:
+  - rvm get head # required by JRuby > 9.0.1.0
+  - rvm reload 
 rvm:
   - 2.0.0
   - 2.1.0
@@ -19,6 +22,7 @@ rvm:
   - rbx-2
   - jruby-head
   - jruby-9000
+  - jruby-9.0.1.0
 
 matrix:
   allow_failures:

--- a/lib/lotus/action/mime.rb
+++ b/lib/lotus/action/mime.rb
@@ -477,6 +477,9 @@ module Lotus
         # See https://github.com/lotus/controller/issues/104
         values = values.reverse unless Lotus::Utils.jruby?
 
+        # https://github.com/jruby/jruby/issues/3004
+        values.sort!            if Lotus::Utils.jruby?
+
         value  = values.sort_by do |match, quality|
           (match.split('/', 2).count('*') * -10) + quality
         end.last


### PR DESCRIPTION
There is a difference in how JRuby and MRI sort_by algorithm works when sorting elements with the same weight. More info: https://github.com/jruby/jruby/issues/3004
  
Calling #sort! before #sort_by in JRuby appears to make it work just like MRI does.