### PR TITLE
Allow to force custom headers for responses that shouldn't include them

### DIFF
--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -1056,6 +1056,26 @@ module HeadTest
         self.body   = 'code'
       end
     end
+
+    class Override
+      include HeadTest::Action
+
+      def call(params)
+        self.headers.merge!(
+          'Last-Modified' => 'Fri, 27 Nov 2015 13:32:36 GMT',
+          'X-Rate-Limit'  => '4000',
+          'X-No-Pass'     => 'true'
+        )
+
+        self.status = 204
+      end
+
+      private
+
+      def keep_response_header?(header)
+        super || 'X-Rate-Limit' == header
+      end
+    end
   end
 end
 


### PR DESCRIPTION
According to RFC 2616, when a response MUST have an empty body, it only allows Entity Headers.

For instance, a <tt>204</tt> doesn't allow <tt>Content-Type</tt> or any other custom header.

This restriction is enforced by <tt>Lotus::Action::Head#finish</tt>.

However, there are cases that demand to bypass this rule to set meta
informations via headers.

An example is a <tt>DELETE</tt> request for a JSON API application. It returns a <tt>204</tt> but still wants to specify the rate limit quota via <tt>X-Rate-Limit</tt>.


```ruby
require 'lotus/controller'

module Books
  class Destroy
    include Lotus::Action

    def call(params)
      # ...
      self.headers.merge!(
        'Last-Modified' => 'Fri, 27 Nov 2015 13:32:36 GMT',
        'X-Rate-Limit'  => '4000',
        'Content-Type'  => 'application/json',
        'X-No-Pass'     => 'true'
      )

      self.status = 204
    end

    private

    def keep_response_header?(header)
      super || header == 'X-Rate-Limit'
    end
  end
end
```

Only the following headers will be sent:

  * `Last-Modified` - because we used `super' in the method that respects the HTTP RFC
  * `X-Rate-Limit`  - because we explicitely allow it

Both `Content-Type` and `X-No-Pass` are removed because they're not allowed

If there are no objections, I would release `v0.4.6` with only this change, because needed by a project I'm working on.

/cc @lotus/core-team