### PR TITLE
Removed Lotus::Controller::Configuration#default_format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Complete, fast and testable actions for Rack
 - [Cainã Costa] Ensure Rack environment to be always available for sessions unit tests
 
 ### Changed
+- [Luca Guidi] Removed `Lotus::Controller::Configuration#default_format`
 - [Cainã Costa] Made `Lotus::Action#session` a public method for improved unit testing
 - [Karim Tarek] Introduced `Lotus::Controller::Error` and let all the framework exceptions to inherit from it.
 

--- a/lib/lotus/controller/configuration.rb
+++ b/lib/lotus/controller/configuration.rb
@@ -450,17 +450,6 @@ module Lotus
         end
       end
 
-      # Set a format as default fallback for all the requests without a strict
-      # requirement for the mime type.
-      #
-      # @since 0.2.0
-      #
-      # @deprecated Use {#default_request_format} instead.
-      def default_format(format = nil)
-        Lotus::Utils::Deprecation.new('default_format is deprecated, please use default_request_format')
-        default_request_format(format)
-      end
-
       # Set a format to be used for all responses regardless of the request type.
       #
       # The given format must be coercible to a symbol, and be a valid mime type

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -187,47 +187,6 @@ describe Lotus::Controller::Configuration do
     end
   end
 
-  describe '#default_format' do
-
-    describe "deprecation" do
-      it "outputs deprecation warning" do
-        _, err = capture_io do
-          @configuration.default_format :html
-        end
-        err.must_include "default_format is deprecated, please use default_request_format"
-      end
-    end
-
-    require 'lotus/utils/io'
-    describe "when not previously set" do
-      it 'returns nil' do
-        Lotus::Utils::IO.silence_warnings do
-          @configuration.default_format.must_be_nil
-        end
-      end
-    end
-
-    describe "when set" do
-      before do
-        Lotus::Utils::IO.silence_warnings do
-          @configuration.default_format :html
-        end
-      end
-
-      it 'returns the value' do
-        Lotus::Utils::IO.silence_warnings do
-          @configuration.default_format.must_equal :html
-        end
-      end
-    end
-
-    it 'raises an error if the given format cannot be coerced into symbol' do
-      Lotus::Utils::IO.silence_warnings do
-        -> { @configuration.default_format(23) }.must_raise TypeError
-      end
-    end
-  end
-
   describe '#default_request_format' do
     describe "when not previously set" do
       it 'returns nil' do


### PR DESCRIPTION
It was deprecated by `v0.4.5` (17c5685bca5d49ced1b439f9c6631b7ae9a06c2a)