### PR TITLE
Exception handling: ensure superclass exception to not shadow subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Complete, fast and testable actions for Rack
 
 ### Fixed
 - [Cainã Costa] Ensure Rack environment to be always available for sessions unit tests
+- [Luca Guidi] Ensure superclass exceptions to not shadow subclasses during exception handling (eg. `CustomError` handler will take precedence over `StandardError`)
 
 ### Changed
 - [Luca Guidi] Removed `Lotus::Controller::Configuration#default_format`

--- a/lib/lotus/controller/configuration.rb
+++ b/lib/lotus/controller/configuration.rb
@@ -180,6 +180,7 @@ module Lotus
       #   end
       def handle_exception(exception)
         @handled_exceptions.merge!(exception)
+        _sort_handled_exceptions!
       end
 
       # Return a callable handler for the given exception
@@ -682,6 +683,13 @@ module Lotus
       end
 
       protected
+      # @since 0.5.0
+      # @api private
+      def _sort_handled_exceptions!
+        @handled_exceptions = Hash[
+          @handled_exceptions.sort{|(ex1,_),(ex2,_)| ex1.ancestors.include?(ex2) ? -1 : 1 }
+        ]
+      end
 
       attr_accessor :handled_exceptions
       attr_accessor :formats

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -126,8 +126,8 @@ end
 class ErrorCallFromInheritedErrorClassStack
   include Lotus::Action
 
-  handle_exception MyCustomError => :handler
   handle_exception StandardError => :standard_handler
+  handle_exception MyCustomError => :handler
 
   def call(params)
     raise MyCustomError


### PR DESCRIPTION
## The Problem

This fixes the following use case.

We have a custom error that inheriths from `StandardError`

```ruby
class MyCustomError < StandardError
end
```

In the `prepare` block we add a handler for generic errors `StandardError`

```ruby
Lotus::Controller.configure do
  prepare do
    handle_exception StandardError => 500
  end
end
```

In an action we have an handler for our custom error. 

```ruby
class MyAction
  include Lotus::Action
  handle_exception MyCustomError => 400

  def call(params)
    # ...
  end
end
```

Because we added first the handler for `StandardError`, we have the following handled exceptions for `MyAction`:

```ruby
{StandardError=>500, MyCustomError=>400}
```

Now, because `StandardError` is a superclass for `MyCustomError`, it shadows our error because of this change introduced by #119 

```
# Lotus::Controller::Configuration

      def exception_handler(exception)
        handler = nil

        @handled_exceptions.each do |exception_class, h|
          if exception.kind_of?(exception_class)
            handler = h
            break
          end
        end

        handler || DEFAULT_ERROR_CODE
      end
```

When `MyCustomError` is raised, `exception.is_a?(exception_class)` returns `true`, because of the exception hierarchy described above.

## The Fix

We sort internally the exceptions according to their hierarchy. That means the handled exceptions for `MyAction` will now be:

```ruby
{MyCustomError=>400, StandardError=>500}
```

When we look for the proper handler, we'll find first the subclass.

---
Ref: #119
/cc @lotus/core-team @manuwell @weppos 