### PR TITLE
Fixed `Set-Cookie` header send twice in second and following request

### DIFF
--- a/lib/lotus/action/cookie_jar.rb
+++ b/lib/lotus/action/cookie_jar.rb
@@ -16,6 +16,12 @@ module Lotus
       # @api private
       HTTP_HEADER       = 'HTTP_COOKIE'.freeze
 
+      # The key used by Rack to set the session cookie
+      #
+      # @since x.x.x
+      # @api private
+      RACK_SESSION_KEY   = :'rack.session'
+
       # The key used by Rack to set the cookies as an Hash in the env
       #
       # @since 0.1.0
@@ -55,6 +61,7 @@ module Lotus
       #
       # @see Lotus::Action::Cookies#finish
       def finish
+        @cookies.delete(RACK_SESSION_KEY)
         @cookies.each { |k,v| v.nil? ? delete_cookie(k) : set_cookie(k, _merge_default_values(v)) }
       end
 

--- a/test/integration/sessions_with_cookies_test.rb
+++ b/test/integration/sessions_with_cookies_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+require 'rack/test'
+
+describe 'Sessions with cookies application' do
+  include Rack::Test::Methods
+
+  def app
+    SessionWithCookies::Application.new
+  end
+
+  def response
+    last_response
+  end
+
+  it 'Set-Cookie with rack.session value is sent only one time' do
+    get '/', {}, 'HTTP_ACCEPT' => 'text/html'
+
+    set_cookie_value = response.headers["Set-Cookie"]
+    rack_session     = /(rack.session=.+);/i.match(set_cookie_value).captures.first.gsub("; path=/", "")
+
+    get '/', {}, {'HTTP_ACCEPT' => 'text/html', 'Cookie' => rack_session}
+
+    response.headers["Set-Cookie"].must_include rack_session
+  end
+end

--- a/test/integration/sessions_without_cookies_test.rb
+++ b/test/integration/sessions_without_cookies_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+require 'rack/test'
+
+describe 'Sessions without cookies application' do
+  include Rack::Test::Methods
+
+  def app
+    SessionsWithoutCookies::Application.new
+  end
+
+  def response
+    last_response
+  end
+
+  it 'Set-Cookie with rack.session value is sent only one time' do
+    get '/', {}, 'HTTP_ACCEPT' => 'text/html'
+
+    set_cookie_value = response.headers["Set-Cookie"]
+    rack_session = /(rack.session=.+);/i.match(set_cookie_value).captures.first.gsub("; path=/", "")
+
+    get '/', {}, {'HTTP_ACCEPT' => 'text/html', 'Cookie' => rack_session}
+
+    response.headers["Set-Cookie"].must_be_nil
+  end
+end


### PR DESCRIPTION
This PR resolves #138 

### The problem
If we have cookies and sessions enabled in `application.rb` like:
```ruby
cookies true
sessions :cookie, secret: 'SECRET'
```
and we make a first request to one endpoint of our Application we have the following cookie in the response:
```ruby
Set-Cookie: rack.session=hash; path="/"; HttpOnly;
```
and the cookie session is set in out browser.

If we make a second request, then the following header in request is sent:
```ruby
Cookie: rack.session=hash
```
and the following headers in the response:
```ruby
Set-Cookie: rack.session=hash; path="/"; HttpOnly;
Set-Cookie: rack.session=hash; path="/"; HttpOnly;
```
Because the Cookie is sent in the second request and followings we shouldn't get `Set-Cookie` headers for `rack.session`.

---

cc @lotus/core-team 